### PR TITLE
Skip unstable high precision unit tests and maintainer list for CRAN submission compliance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Rforestry: Random Forests, Linear Trees, and Gradient Boosting for Inference and Interpretability
 Version: 0.9.0.3
 Author: Sören Künzel, Theo Saarinen, Simon Walter, Edward Liu, Allen Tang, Jasjeet Sekhon
-Maintainer: Theo Saarinen <theo_s@berkeley.edu>, Jasjeet Sekhon <jasjeet.sekhon@yale.edu>, Sören Künzel <srk@berkeley.edu>
+Maintainer: Theo Saarinen <theo_s@berkeley.edu>
 Description: Random Forests, Linear Trees, and Gradient Boosting for inference and interpretability.
 License: GPL (>=3) | file LICENSE
 Encoding: UTF-8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![R-CMD-check](https://github.com/linanqiu/Rforestry/actions/workflows/check-noncontainerized.yaml/badge.svg)](https://github.com/linanqiu/Rforestry/actions/workflows/check-noncontainerized.yaml)
-
+[![R-CMD-check](https://github.com/forestry-labs/Rforestry/actions/workflows/check-noncontainerized.yaml/badge.svg)](https://github.com/forestry-labs/Rforestry/actions/workflows/check-noncontainerized.yaml)
 
 ## Rforestry: Random Forests, Linear Trees, and Gradient Boosting for Inference and Interpretability
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,11 @@
+is_mac <- function() {
+  return(grepl('darwin', R.Version()$platform, ignore.case = TRUE))
+}
+
+skip_if_not_mac <- function() {
+  if(is_mac()) {
+    return(invisible(TRUE))
+  }
+
+  skip('Not run on non-mac platforms due to non-deterministic randomness in implementation of std::uniform_int_distribution across different compilers. Test cases were written only for macOS (clang). We have not had time to write tests for other compilers like gcc yet.')
+}

--- a/tests/testthat/test-OOBpredictions.R
+++ b/tests/testthat/test-OOBpredictions.R
@@ -1,4 +1,4 @@
-test_that("Tests if OOB predictions are working correctly", {
+test_that("Tests if OOB predictions are working correctly (normal setting)", {
   x <- iris[, -1]
   y <- iris[, 1]
   context('OOB Predictions')
@@ -23,12 +23,23 @@ test_that("Tests if OOB predictions are working correctly", {
   # Test OOB predictions
   expect_equal(sum((getOOBpreds(forest) -  iris[,1])^2), getOOB(forest), tolerance = 1e-5)
 
+  skip_if_not_mac()
 
   expect_equal(all.equal(getOOBpreds(forest)[1:10], c(5.092647817, 4.664031165,
                                                       4.650426049, 4.870883947,
                                                       5.084049999, 5.344246144,
                                                       5.069991851, 5.060238528,
                                                       4.766551234, 4.790776227)), TRUE)
+})
+
+
+test_that("Tests if OOB predictions are working correctly (extreme setting)", {
+  x <- iris[, -1]
+  y <- iris[, 1]
+  context('OOB Predictions')
+  # Set seed for reproductivity
+  set.seed(24750371)
+
   # Test a very extreme setting
   forest <- forestry(
     x,

--- a/tests/testthat/test-compute_rf_lp.R
+++ b/tests/testthat/test-compute_rf_lp.R
@@ -30,6 +30,8 @@ test_that("Tests that compute the lp distances works correctly", {
   expect_identical(length(distances_2), nrow(x_test))
 
   #set tolerance
+  skip_if_not_mac()
+
   expect_equal(distances_1,
                c(0.74127647652339, 0.56269154186560, 0.66700207007833, 0.48143305071905,
                  0.42691537245113, 0.79361471149614, 0.69064814060102, 0.60005881782247,

--- a/tests/testthat/test-forestry.R
+++ b/tests/testthat/test-forestry.R
@@ -28,6 +28,8 @@ test_that("Tests that random forest is working correctly", {
   expect_equal(y_pred, y_pred_shuffled, tolerance = 1e-12)
 
   # Mean Square Error
+  skip_if_not_mac()
+
   mean((y_pred - y) ^ 2)
   expect_equal(mean((y_pred - y) ^ 2), 0.064760523023031, tolerance = 1e-12)
 

--- a/tests/testthat/test-imputation_monotonicity.R
+++ b/tests/testthat/test-imputation_monotonicity.R
@@ -42,11 +42,19 @@ test_that("Tests that Monotone splits parameter is working correctly in the case
   pred_means <- sapply(c(1,4,9,15), function(x) {mean(predict(monotone_forest,
                                                              feature.new = data.frame(V1 = rep(x, 100))))})
 
+  skip_if_not_mac()
+
   # Mean Square Error
   #print(pred_means)
-  expect_equal(all.equal(order(pred_means), 4:1), TRUE)
 
+  expect_equal(all.equal(order(pred_means), 4:1), TRUE)
+})
+
+
+test_that("Tests that Monotone splits parameter is working correctly in the case of missing data (sine wave)", {
   set.seed(23423324)
+
+  context('Positive monotone splits with missing data')
 
   # Sine wave example. Suppose we have a slight trend upwards, but this is
   # complicated by some oscillations, we can then constrain monotonicity to avoid

--- a/tests/testthat/test-impute_features.R
+++ b/tests/testthat/test-impute_features.R
@@ -15,6 +15,8 @@ x_with_miss[idx_miss_factor, "Species"] <- NA
 idx_miss_numeric <- sample(nrow(x), 50, replace = TRUE)
 x_with_miss[idx_miss_numeric, "Sepal.Width"] <- NA
 
+skip_if_not_mac()
+
 forest <- forestry(x_with_miss, y, ntree = 500, seed = 2, nthread = 1)
 imputed_x <- impute_features(forest, x_with_miss, seed = 2)
 expect_equal(sum(imputed_x$Species != x$Species), 2)

--- a/tests/testthat/test-max-depth.R
+++ b/tests/testthat/test-max-depth.R
@@ -25,6 +25,8 @@ test_that("Tests that maxDepth parameter is working correctly", {
   # Test predict
   y_pred <- predict(forest, x)
 
+  skip_if_not_mac()
+
   # Mean Square Error
   expect_equal(sum((y_pred - y) ^ 2), 11.076804560351238393, tolerance = 1e-12)
 })

--- a/tests/testthat/test-multilayerForestry.R
+++ b/tests/testthat/test-multilayerForestry.R
@@ -28,6 +28,9 @@ test_that("Tests that multilayerForestry is working correctly", {
 
   # Mean Square Error
   sum((y_pred - y) ^ 2)
+
+  skip_if_not_mac()
+
   # Multilayer forestry is non deterministic, this needs to be fixed, but for
   # now test that it at least runs without crashing
   expect_equal(sum((y_pred - y) ^ 2), 13.849777575910220, tolerance = 1e-8)

--- a/tests/testthat/test-observationWeights.R
+++ b/tests/testthat/test-observationWeights.R
@@ -28,6 +28,8 @@ test_that("Tests that observationWeights for the bootstrap is working correctly"
   # Mean Square Error
   sum((y_pred - y) ^ 2)
 
+  skip_if_not_mac()
+
   # Check the predictions from a weighted forest
   expect_equal(sum((y_pred - y) ^ 2), 8.658285584297157, tolerance = 1e-8)
 

--- a/tests/testthat/test-terminalNodes.R
+++ b/tests/testthat/test-terminalNodes.R
@@ -15,6 +15,8 @@ test_that("Tests that terminal nodes are correct", {
     maxDepth = 5
   )
 
+  skip_if_not_mac()
+
   # Test predict
   full_predictions <- predict(forest, x[c(5, 100, 104),], aggregation = 'weightMatrix')$terminalNodes
   expect_equal(full_predictions, matrix(c(5,14,14,19), ncol = 1))


### PR DESCRIPTION
* Skips unstable high precision tests on windows and linux due to differing implementations of `std::uniform_int_distribution` on `gcc` and `clang`. The unit tests were written with `clang` in mind and hence fail on `gcc`
* Changed maintainer to single person to comply with CRAN requirements. Good luck with the emails @theo-s 