### PR TITLE
Enforce that length of groups parameter must be equal to number of observations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rforestry
 Type: Package
 Title: Random Forests, Linear Trees, and Gradient Boosting for Inference and Interpretability
-Version: 0.9.0.144
+Version: 0.9.0.145
 Authors@R: c(
     person("Sören", "Künzel", role = "aut"),
     person("Theo", "Saarinen", role = c("aut","cre"), email = "theo_s@berkeley.edu"),

--- a/R/forestry.R
+++ b/R/forestry.R
@@ -241,6 +241,9 @@ training_data_checker <- function(x,
     if (length(levels(groups)) == 1) {
       stop("groups must have more than 1 level to be left out from sampling")
     }
+    if (length(groups) != nrow(x)) {
+      stop("Length of groups must equal the number of observations")
+    }
   }
 
   if (OOBhonest && (splitratio != 1)) {

--- a/tests/testthat/test-groups.R
+++ b/tests/testthat/test-groups.R
@@ -1,8 +1,22 @@
 test_that("Tests if groups argument works works", {
-  context('Tests groups')
+  context("Test check that length of groups must equal number of observations")
+  x <- iris[1:40,-c(1, 5)]
+  y <- iris[1:40, 1]
 
-  x <- iris[1:40,-c(1,5)]
-  y <- iris[1:40,1]
+  expect_error(
+    rf <- forestry(
+      x = x,
+      y = y,
+      groups = as.factor(1:10),
+      replace = TRUE,
+      OOBhonest = TRUE,
+      ntree = 1,
+      seed = 2332
+    ),
+    "Length of groups must equal the number of observations"
+  )
+
+  context('Tests groups')
 
   group_vec = as.factor(1:40)
 


### PR DESCRIPTION
Avoids issues highlighted in https://github.com/forestry-labs/Rforestry/issues/35 and https://github.com/forestry-labs/Rforestry/issues/37.