### PR TITLE
Introduce get_path function for parity with Python API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rforestry
 Type: Package
 Title: Random Forests, Linear Trees, and Gradient Boosting for Inference and Interpretability
-Version: 0.9.0.158
+Version: 0.9.0.159
 Authors@R: c(
     person("Sören", "Künzel", role = "aut"),
     person("Theo", "Saarinen", role = c("aut","cre"), email = "theo_s@berkeley.edu"),

--- a/src/DataFrame.cpp
+++ b/src/DataFrame.cpp
@@ -9,7 +9,6 @@ DataFrame::DataFrame():
   _monotonicConstraints(nullptr), _groupMemberships(nullptr){}
 
 DataFrame::~DataFrame() {
-//  std::cout << "DataFrame() destructor is called." << std::endl;
 }
 
 DataFrame::DataFrame(

--- a/src/DataFrame.cpp
+++ b/src/DataFrame.cpp
@@ -8,8 +8,7 @@ DataFrame::DataFrame():
   _deepFeatureWeightsVariables(nullptr), _observationWeights(nullptr),
   _monotonicConstraints(nullptr), _groupMemberships(nullptr){}
 
-DataFrame::~DataFrame() {
-}
+DataFrame::~DataFrame(){};
 
 DataFrame::DataFrame(
   std::shared_ptr< std::vector< std::vector<double> > > featureData,

--- a/src/RFNode.cpp
+++ b/src/RFNode.cpp
@@ -16,7 +16,6 @@ RFNode::RFNode():
   _naDefaultDirection(0), _averageCount(0), _splitCount(0) {}
 
 RFNode::~RFNode() {
-  //  std::cout << "RFNode() destructor is called." << std::endl;
 };
 
 void RFNode::setLeafNode(
@@ -96,7 +95,7 @@ void RFNode::setRidgeCoefficients(
     arma::Mat<double> y(outcomePoints.size(),
                         1);
     y.col(0) = arma::conv_to<arma::Col<double> >::from(outcomePoints);
-    //Compute XtX + lambda * I * Y = C
+    // Compute XtX + lambda * I * Y = C
     arma::Mat<double> coefficients = (x.t() * x +
                                       identity * lambda).i() * x.t() * y;
 
@@ -136,7 +135,7 @@ void RFNode::ridgePredict(
     index++;
   }
 
-  //Multiply xNew * coefficients = result
+  // Multiply xNew * coefficients = result
   arma::Mat<double> predictions = xn * coefficients;
 
   for (size_t i = 0; i < updateIndex->size(); i++) {
@@ -219,7 +218,6 @@ void RFNode::predict(
           it != (*updateIndex).end();
           ++it ) {
         // Set the row which we update in the weightMatrix
-        //
         size_t idx = *it;
         if (OOBIndex) {
           idx = (*OOBIndex)[*it];
@@ -535,15 +533,6 @@ void RFNode::predict(
 
 bool RFNode::is_leaf() {
   int ave_ct = getAverageCount();
-  //int spl_ct = getSplitCount();
-  // if (
-  //     (ave_ct == 0 && spl_ct != 0) ||(ave_ct != 0 && spl_ct == 0)
-  // ) {
-  //   throw std::runtime_error(
-  //       "Average count or Split count is 0, while the other is not!"
-  //       );
-  // }
-  //return !(ave_ct == 0 && spl_ct == 0);
   return !(ave_ct == 0);
 }
 

--- a/src/RFNode.cpp
+++ b/src/RFNode.cpp
@@ -15,8 +15,7 @@ RFNode::RFNode():
   _leftChild(nullptr),_rightChild(nullptr),_naLeftCount(0), _naRightCount(0),
   _naDefaultDirection(0), _averageCount(0), _splitCount(0) {}
 
-RFNode::~RFNode() {
-};
+RFNode::~RFNode(){};
 
 void RFNode::setLeafNode(
         size_t averagingSampleIndexSize,

--- a/src/RFNode.h
+++ b/src/RFNode.h
@@ -39,7 +39,6 @@ public:
           double lambda
   );
 
-
   void ridgePredict(
       std::vector<double> &outputPrediction,
       std::vector< std::vector<double> > &outputCoefficients,
@@ -64,6 +63,13 @@ public:
     unsigned int seed,
     size_t nodesizeStrictAvg,
     std::vector<size_t>* OOBIndex = NULL
+  );
+
+  void getPath(
+      std::vector<size_t> &path,
+      std::vector<double>* xNew,
+      DataFrame* trainingData,
+      unsigned int seed
   );
 
   void write_node_info(

--- a/src/forestry.cpp
+++ b/src/forestry.cpp
@@ -20,12 +20,6 @@ forestry::forestry():
   _nthread(0), _OOBError(0), _splitMiddle(0),_minTreesPerFold(0), _doubleTree(0){};
 
 forestry::~forestry(){
-//  for (std::vector<forestryTree*>::iterator it = (*_forest).begin();
-//       it != (*_forest).end();
-//       ++it) {
-//    delete(*it);
-//  }
-//  std::cout << "forestry() destructor is called." << std::endl;
 };
 
 forestry::forestry(
@@ -346,7 +340,6 @@ void forestry::addTrees(size_t ntree) {
             }
 
           } catch (std::runtime_error &err) {
-            // Rcpp::Rcerr << err.what() << std::endl;
           }
 
         }
@@ -1008,7 +1001,6 @@ void forestry::reconstructTrees(
     for(int i=0; i<(split_vals->size()); i++ ) {
     #endif
 
-    // for (size_t i=0; i<split_vals->size(); i++) {
       try{
         forestryTree *oneTree = new forestryTree();
 
@@ -1135,6 +1127,4 @@ std::vector<std::vector<double>>* forestry::neighborhoodImpute(
           (*xNew)[j][i] = maxPosition;
         }}}
   return xNew;
-  //return weightMatrix;
-
 }

--- a/src/forestry.cpp
+++ b/src/forestry.cpp
@@ -19,8 +19,7 @@ forestry::forestry():
   _maxDepth(0), _interactionDepth(0), _forest(nullptr), _seed(0), _verbose(0),
   _nthread(0), _OOBError(0), _splitMiddle(0),_minTreesPerFold(0), _doubleTree(0){};
 
-forestry::~forestry(){
-};
+forestry::~forestry(){};
 
 forestry::forestry(
   DataFrame* trainingData,

--- a/src/forestryTree.cpp
+++ b/src/forestryTree.cpp
@@ -1309,8 +1309,6 @@ void forestryTree::getOOBhonestIndex(
   );
   OOBIndex.resize((unsigned long) (it - OOBIndex.begin()));
 
-  //std::cout << "OOB index inside get OOB HonestIndex" << std::endl;
-  //  print_vector(OOBIndex);
   for (
       std::vector<size_t>::iterator it_ = OOBIndex.begin();
       it_ != OOBIndex.end();

--- a/src/rcpp_cppBuildInterface.cpp
+++ b/src/rcpp_cppBuildInterface.cpp
@@ -213,7 +213,6 @@ SEXP rcpp_cppBuildInterface(
         doubleTree
       );
 
-      // delete(testFullForest);
       Rcpp::XPtr<forestry> ptr(testFullForest, true) ;
       R_RegisterCFinalizerEx(
         ptr,
@@ -345,8 +344,6 @@ SEXP rcpp_cppBuildInterface(
         (double) overfitPenalty,
         doubleTree
       );
-
-      // delete(testFullForest);
       Rcpp::XPtr<forestry> ptr(testFullForest, true) ;
       R_RegisterCFinalizerEx(
         ptr,
@@ -686,37 +683,16 @@ Rcpp::List rcpp_CppToR_translator(
     );
     (*testFullForest).fillinTreeInfo(forest_dta);
 
-    //   Print statements for debugging
-    // std::cout << "hello\n";
-    // std::cout.flush();
-
     // Return the lis of list. For each tree an element in the first list:
     Rcpp::List list_to_return;
 
     for(size_t i=0; i!=forest_dta->size(); i++){
       Rcpp::IntegerVector var_id = Rcpp::wrap(((*forest_dta)[i]).var_id);
-
-      // std::cout << "var_id\n";
-      // std::cout.flush();
-
       Rcpp::NumericVector split_val = Rcpp::wrap(((*forest_dta)[i]).split_val);
-
-      // std::cout << "split_val\n";
-      // std::cout.flush();
-
-
       Rcpp::IntegerVector averagingSampleIndex =
 	      Rcpp::wrap(((*forest_dta)[i]).averagingSampleIndex);
-
-      // std::cout << "averagingSampleIndex\n";
-      // std::cout.flush();
-
       Rcpp::IntegerVector splittingSampleIndex =
 	      Rcpp::wrap(((*forest_dta)[i]).splittingSampleIndex);
-
-      // std::cout << "splittingSampleIndex\n";
-      // std::cout.flush();
-
       Rcpp::IntegerVector naLeftCounts =
         Rcpp::wrap(((*forest_dta)[i]).naLeftCount);
 
@@ -742,18 +718,8 @@ Rcpp::List rcpp_CppToR_translator(
 			   Rcpp::Named("seed") = (*forest_dta)[i].seed, // Add the seeds to the list we return
                Rcpp::Named("weights") = predictWeights
         );
-
-      // std::cout << "finished list\n";
-      // std::cout.flush();
-
       list_to_return.push_back(list_i);
     }
-
-    // std::cout << "hello1\n";
-    // std::cout.flush();
-
-
-
     return list_to_return;
 
   } catch(std::runtime_error const& err) {
@@ -1012,7 +978,6 @@ Rcpp::List rcpp_reconstructree(
                                    predictWeights
                                    );
 
-  // delete(testFullForest);
   Rcpp::XPtr<forestry> ptr(testFullForest, true);
   R_RegisterCFinalizerEx(
     ptr,
@@ -1069,7 +1034,5 @@ std::vector< std::vector<double> > rcpp_cppImputeInterface(
     &featureData,
     &weightMatrixT
   );
-  //auto returnX = Rcpp::as<Rcpp::NumericMatrix>(imputedX);
   return *imputedX;
-  //return weightMatrixT;
 }


### PR DESCRIPTION
The Python C++ API includes a [`getPath()`](https://github.com/theo-s/Rforestry/blob/0651e2ea91d678acd03ac7cb24efb868487c128b/C%2B%2B/src/RFNode.h#L55-L60) function not yet implemented in this repository. This C++ API will be used as the master branch so adding this function to reach parity. After the Python repository is updated to align with this C++ API, it will be merged in this repo. This change also includes some clean-up removing unused commented code. 
Two follow-ups post merge are:
1. Potentially refactor as a flag in the predict function.
2. Include an R wrapper to access the feature.