### PR TITLE
Sample with observation weights in doubleBootstrap without groups

### DIFF
--- a/src/sampling.cpp
+++ b/src/sampling.cpp
@@ -433,16 +433,22 @@ void generate_sample_indices(
         std::vector< size_t > AvgIndices;
 
         // Check the double bootstrap, if true, we take another sample
-        // from the OOB indices, otherwise we just take the OOB index
-        // set with standard (uniform) weightings
+        // from the OOB indices, otherwise we just take the OOB index set.
         if (doubleBootstrap) {
-            std::uniform_int_distribution<size_t> uniform_dist(
-                    0, (size_t) (OOBIndex.size() - 1)
+
+            // Generate a weighted distribution using observationWeights
+            std::vector<double>* sampleWeights = (trainingData->getobservationWeights());
+            for (size_t i = 0; i < sampleIndex.size(); i++) {
+                sampleWeights->at(sampleIndex.at(i)) = 0;
+            }
+
+            std::discrete_distribution<size_t> sample_dist(
+                    sampleWeights->begin(), sampleWeights->end()
             );
 
             // Sample with replacement from OOB Indices for the averaging set
             while (AvgIndices.size() < OOBIndex.size()) {
-                size_t randomIndex = uniform_dist(random_number_generator);
+                size_t randomIndex = sample_dist(random_number_generator);
                 AvgIndices.push_back(
                         OOBIndex[randomIndex]
                 );

--- a/src/sampling.cpp
+++ b/src/sampling.cpp
@@ -437,13 +437,13 @@ void generate_sample_indices(
         if (doubleBootstrap) {
 
             // Generate a weighted distribution using observationWeights
-            std::vector<double>* sampleWeights = (trainingData->getobservationWeights());
+            std::vector<double> sampleWeights = *(trainingData->getobservationWeights());
             for (size_t i = 0; i < sampleIndex.size(); i++) {
-                sampleWeights->at(sampleIndex.at(i)) = 0;
+                sampleWeights.at(sampleIndex.at(i)) = 0;
             }
 
             std::discrete_distribution<size_t> sample_dist(
-                    sampleWeights->begin(), sampleWeights->end()
+                    sampleWeights.begin(), sampleWeights.end()
             );
 
             // Sample with replacement from OOB Indices for the averaging set


### PR DESCRIPTION
Starting this PR as a discussion point for an earlier highlighted [issue](https://github.com/forestry-labs/Rforestry/issues/48#issuecomment-1450787443). When observationWeights are provided without groups, we currently use uniformly sample for the averaging set in the double bootstrap. However when groups are provided, we take a weighted sample. This results in behavior where, if a subset of observations are heavily weighted and therefore likely selected for splitting, averaging set will actually contain almost none of the heavily weighted observations. @theo-s should we adjust this behavior? We should also account for, as you've previously highlighted, that the meaning of the weights may change in the second sample. 

On a secondary note, while we're reviewing sampling, a doubleBootstrap is always taken when groups are provided. We may still want to respect doubleBoostrap = FALSE when groups are set. 