### PR TITLE
Tentative Fix for lack of reproducibility between R + Python

### DIFF
--- a/Python/extension/src/api.cpp
+++ b/Python/extension/src/api.cpp
@@ -48,7 +48,7 @@ extern "C" {
         };
     
         for (size_t i = 0; i < numRows; i++) {
-            outcomeData->at(i) = arr[numColumns*i-1];
+            outcomeData->at(i) = arr[numColumns*(i+1)-1];
         }
     
         numColumns--;

--- a/Python/random_forestry/forestry.py
+++ b/Python/random_forestry/forestry.py
@@ -314,7 +314,7 @@ class RandomForest:
     fold_size: conint(gt=0, strict=True) = 1
     monotone_avg: StrictBool = False
     overfit_penalty: Union[StrictInt, StrictFloat] = 1
-    scale: StrictBool = True
+    scale: StrictBool = False
     double_tree: StrictBool = False
     na_direction: StrictBool = False
 

--- a/Python/random_forestry/forestry.py
+++ b/Python/random_forestry/forestry.py
@@ -314,7 +314,7 @@ class RandomForest:
     fold_size: conint(gt=0, strict=True) = 1
     monotone_avg: StrictBool = False
     overfit_penalty: Union[StrictInt, StrictFloat] = 1
-    scale: StrictBool = False
+    scale: StrictBool = True
     double_tree: StrictBool = False
     na_direction: StrictBool = False
 
@@ -791,7 +791,7 @@ class RandomForest:
         aggregation: str = PredictValidator.DEFAULT_AGGREGATION,
         seed: Optional[int] = None,
         nthread: Optional[int] = None,
-        exact: Optional[bool] = None,
+        exact: Optional[bool] = True,
         trees: Optional[np.ndarray] = None,
         training_idx: Optional[np.ndarray] = None,
         return_weight_matrix: bool = False,

--- a/Python/random_forestry/forestry.py
+++ b/Python/random_forestry/forestry.py
@@ -683,7 +683,7 @@ class RandomForest:
         if newdata is None:
             double_oob = True
         else:
-            double_oob = False
+            double_oob = True
             processed_x = preprocessing.preprocess_testing(
                 newdata,
                 self.processed_dta.categorical_feature_cols,

--- a/Python/random_forestry/forestry.py
+++ b/Python/random_forestry/forestry.py
@@ -640,6 +640,14 @@ class RandomForest:
         )
         return len(processed_x.index)
 
+    def _scale_ret_values(self,
+                          ret_values: Optional[Tuple[np.ndarray, np.ndarray]],
+                          include_coefficients: bool = False
+    ) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+        if include_coefficients:
+            return (ret_values[0] * self.processed_dta.col_sd[-1] + self.processed_dta.col_means[-1], ret_values[1], ret_values[2])
+        return (ret_values[0] * self.processed_dta.col_sd[-1] + self.processed_dta.col_means[-1], ret_values[1])
+
     def _aggregation_oob(
         self,
         newdata: Optional[pd.DataFrame],
@@ -682,7 +690,7 @@ class RandomForest:
         )
         # If the forest was trained with scaled values we need to rescale + re center the predictions
         if self.scale:
-            return (ret_values[0] * self.processed_dta.col_sd[-1] + self.processed_dta.col_means[-1], ret_values[1])
+            return self._scale_ret_values(ret_values)
         else:
             return ret_values
 
@@ -729,7 +737,7 @@ class RandomForest:
 
         # If the forest was trained with scaled values we need to rescale + re center the predictions
         if self.scale:
-            return (ret_values[0]* self.processed_dta.col_sd[-1] + self.processed_dta.col_means[-1], ret_values[1])
+            return self._scale_ret_values(ret_values)
         else:
             return ret_values
 
@@ -765,7 +773,7 @@ class RandomForest:
 
         # If the forest was trained with scaled values we need to rescale + re center the predictions
         if self.scale:
-            return (ret_values[0] * self.processed_dta.col_sd[-1] + self.processed_dta.col_means[-1], ret_values[1],ret_values[2])
+            return self._scale_ret_values(ret_values, include_coefficients=True)
         else:
             return ret_values
 
@@ -818,7 +826,7 @@ class RandomForest:
 
         # If the forest was trained with scaled values we need to rescale + re center the predictions
         if self.scale:
-            return (ret_values[0] * self.processed_dta.col_sd[-1] + self.processed_dta.col_means[-1], ret_values[1],ret_values[2])
+            return self._scale_ret_values(ret_values, include_coefficients=True)
         else:
             return ret_values
 

--- a/Python/random_forestry/forestry.py
+++ b/Python/random_forestry/forestry.py
@@ -680,10 +680,10 @@ class RandomForest:
         return_weight_matrix: bool,
         training_idx: Optional[np.ndarray]
     ) -> Tuple[np.ndarray, np.ndarray]:
-        if newdata is None:
-            double_oob = True
-        else:
-            double_oob = True
+
+        double_oob = True
+
+        if newdata is not None:
             processed_x = preprocessing.preprocess_testing(
                 newdata,
                 self.processed_dta.categorical_feature_cols,

--- a/Python/random_forestry/forestry.py
+++ b/Python/random_forestry/forestry.py
@@ -657,13 +657,12 @@ class RandomForest:
                 raise ValueError("Attempting to do OOB predictions on a dataset which doesn't match the training data!")
             if training_idx and len(training_idx) != len(newdata.index):
                 raise ValueError("Training Indices must be of the same length as newdata")
+            if self.scale:
+                processed_x = preprocessing.scale_center(processed_x, self.processed_dta.categorical_feature_cols,
+                                                         self.processed_dta.col_means,self.processed_dta.col_sd)
 
         if training_idx and (not np.issubdtype(training_idx.dtype, np.integer) or np.any((training_idx < 0) | (training_idx >= self.processed_dta.n_observations))):
             raise ValueError("Training Indices must contain integers between 0 and the number of training observations - 1")
-
-        if newdata is not None and self.scale:
-            processed_x = preprocessing.scale_center(processed_x, self.processed_dta.categorical_feature_cols,
-                                                     self.processed_dta.col_means,self.processed_dta.col_sd)
 
         n_preds = self._get_n_preds(newdata)
         n_weight_matrix = n_preds * self.processed_dta.n_observations if return_weight_matrix else 0
@@ -694,9 +693,6 @@ class RandomForest:
         return_weight_matrix: bool,
         training_idx: Optional[np.ndarray]
     ) -> Tuple[np.ndarray, np.ndarray]:
-
-        double_oob = True
-
         if newdata is not None:
             processed_x = preprocessing.preprocess_testing(
                 newdata,
@@ -707,13 +703,12 @@ class RandomForest:
                 raise ValueError("Attempting to do OOB predictions on a dataset which doesn't match the training data!")
             if training_idx and len(training_idx) != len(newdata.index):
                 raise ValueError("Training Indices must be of the same length as newdata")
+            if self.scale:
+                processed_x = preprocessing.scale_center(processed_x, self.processed_dta.categorical_feature_cols,
+                                                         self.processed_dta.col_means,self.processed_dta.col_sd)
 
         if training_idx and (not np.issubdtype(training_idx.dtype, np.integer) or np.any((training_idx < 0) | (training_idx >= self.processed_dta.n_observations))):
             raise ValueError("Training Indices must contain integers between 0 and the number of training observations - 1")
-
-        if newdata is not None and self.scale:
-            processed_x = preprocessing.scale_center(processed_x, self.processed_dta.categorical_feature_cols,
-                                                     self.processed_dta.col_means,self.processed_dta.col_sd)
 
         n_preds = self._get_n_preds(newdata)
         n_weight_matrix = n_preds * self.processed_dta.n_observations if return_weight_matrix else 0
@@ -722,7 +717,7 @@ class RandomForest:
             self.forest,
             self.dataframe,
             self._get_test_data(processed_x),
-            double_oob,
+            True,
             exact,
             return_weight_matrix,
             self.verbose,
@@ -835,7 +830,7 @@ class RandomForest:
         aggregation: str = PredictValidator.DEFAULT_AGGREGATION,
         seed: Optional[int] = None,
         nthread: Optional[int] = None,
-        exact: Optional[bool] = True,
+        exact: bool = True,
         trees: Optional[np.ndarray] = None,
         training_idx: Optional[np.ndarray] = None,
         return_weight_matrix: bool = False,


### PR DESCRIPTION
This PR fixes several differences in hyper parameters between the two packages (**exact**, **scale** etc.) There is a problem with scaling in the Python package, it should be easy to fix, the predictions just need to be scaled and centered correctly, and the values should be stored already. I have opened an issue for this.

The main bug that this fixes is related to the indexing of the vector of outcomes when it is passed to C++. The indexing in the API was off by 1, but since the vector was not empty, this didn't throw an error, and instead populated the first entry in the outcome vector with 0. So an outcome vector `(y_0, y_1, y_3, ... y_n)` was passed to C++ as  `(0, y_0, y_1, ... y_{n-1))`. 

This resulted in the tree structure differing from that constructed in C++ by the R package despite the seed being passed correctly, the covariates being passed correctly, and seemingly all of the other hyper parameters being passed correctly. Since the outcomes were shifted, this explains why the predictions had worse predictive power than those generated from the R package. 

In my examples, I am now getting exactly matching predictions + MSE values across aggregation = "average", aggregation = "oob", and aggregation = "doubleOOB". **We should continue testing as there may be similar problems that appear with other hyper parameter combinations, and would be hard to detect while this problem was present.** 

Through the process of debugging this, I have tested and am pretty confident that:

- The covariates and outcomes are being passed to C++ are now consistent across both packages.
- Hyperparameters for the trees are being passed to C++ consistently across both packages.
- The seeds for the trees are being passed to C++ consistently across both packages. 
- The sampled splitting and averaging indices for each tree are replicated across both packages when the seed is set.
- When the forest is trained with multiple trees and predicts with multiple trees in parallel, the predictions of the trees and the ordering of trees in the C++ forest (after being sorted by seed) are consistent across both packages.
- Conditioning on seed, the trees built in C++ are consistent across both packages for the hyper parameters I tested (**OOBhonest**, **scale**, **mtry**,**ntree**,**maxDepth**)


What I have not tested yet, and should be tested:

- Aggregation with weightMatrix or coefficients.
- Saving and loading a forest to make sure this doesn't mess up the C++ forest after reloading.
- Other combinations of hyper parameters.

