### PR TITLE
Remove b2 tag from Python versioning

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -43,7 +43,7 @@ line-length = 120
 profile = "black"
 
 [tool.bumpver]
-current_version = "0.10.0-b2"
+current_version = "0.10.0"
 version_pattern = "MAJOR.MINOR.PATCH[-PYTAGNUM]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "random-forestry"
-version = "0.10.0-b2"
+version = "0.10.0"
 description = "Random forest estimator"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/Python/random_forestry/__init__.py
+++ b/Python/random_forestry/__init__.py
@@ -1,4 +1,4 @@
 from .forestry import RandomForest
 
 # Version of Rforestry
-__version__ = "0.10.0-b2"
+__version__ = "0.10.0"


### PR DESCRIPTION
Updates PyPI release to include: 
- exact reproducibility with R version
- fix for groups
- observation weights without groups